### PR TITLE
Potential fix for code scanning alert no. 32: Uncontrolled data used in path expression

### DIFF
--- a/zerver/views/upload.py
+++ b/zerver/views/upload.py
@@ -427,7 +427,9 @@ def serve_local_avatar_unauthed(request: HttpRequest, path: str) -> HttpResponse
         url = get_public_upload_root_url() + path
         return redirect(url, permanent=True)
 
-    local_path = os.path.join(settings.LOCAL_AVATARS_DIR, path)
+    local_path = os.path.normpath(os.path.join(settings.LOCAL_AVATARS_DIR, path))
+    if not local_path.startswith(os.path.normpath(settings.LOCAL_AVATARS_DIR)):
+        raise JsonableError(_("Invalid path"))
     assert_is_local_storage_path("avatars", local_path)
     if not os.path.isfile(local_path):
         return HttpResponseNotFound("<p>File not found</p>")


### PR DESCRIPTION
Potential fix for [https://github.com/codeallthethingsbreak/zulip/security/code-scanning/32](https://github.com/codeallthethingsbreak/zulip/security/code-scanning/32)

To fix the issue, we need to validate the `local_path` constructed from the user-provided `path` parameter. This involves normalizing the path using `os.path.normpath` and ensuring that the resulting path is contained within the `settings.LOCAL_AVATARS_DIR` directory. This approach prevents path traversal attacks by removing any `..` segments and verifying the directory containment.

Steps to implement the fix:
1. Normalize the `local_path` using `os.path.normpath`.
2. Check that the normalized path starts with `settings.LOCAL_AVATARS_DIR`.
3. Raise an exception or return an error response if the validation fails.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
